### PR TITLE
Bugfix: Fixed dependencies for SilverStripe 4.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,16 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/recipe-plugin": "^1",
-        "silverstripe/recipe-core": "1.1.0@stable",
-        "silverstripe/admin": "1.1.0@stable",
-        "silverstripe/asset-admin": "1.1.0@stable",
-        "silverstripe/campaign-admin": "1.1.0@stable",
-        "silverstripe/cms": "4.1.0@stable",
-        "silverstripe/errorpage": "1.1.0@stable",
-        "silverstripe/graphql": "1.1.0@stable",
-        "silverstripe/reports": "4.1.0@stable",
-        "silverstripe/siteconfig": "4.1.0@stable",
-        "silverstripe/versioned": "1.1.0@stable"
+        "silverstripe/recipe-core": "1.1.1@stable",
+        "silverstripe/admin": "1.1.1@stable",
+        "silverstripe/asset-admin": "1.1.1@stable",
+        "silverstripe/campaign-admin": "1.1.1@stable",
+        "silverstripe/cms": "4.1.1@stable",
+        "silverstripe/errorpage": "1.1.1@stable",
+        "silverstripe/graphql": "1.1.1@stable",
+        "silverstripe/reports": "4.1.1@stable",
+        "silverstripe/siteconfig": "4.1.1@stable",
+        "silverstripe/versioned": "1.1.1@stable"
     },
     "require-dev": {
         "phpunit/PHPUnit": "^5.7"


### PR DESCRIPTION
The recipe was tagged for 1.1.1 which I assume was to sync up with the release of SilverStripe 4.1.1 however the composer.json did not change see https://github.com/silverstripe/recipe-cms/compare/1.1.1...1.1.0. This pull updates the dependencies to point to the latest versions.