### PR TITLE
include simple theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "silverstripe/graphql": "2.0.x-dev",
         "silverstripe/reports": "4.2.x-dev",
         "silverstripe/siteconfig": "4.2.x-dev",
-        "silverstripe/versioned": "1.2.x-dev"
+        "silverstripe/versioned": "1.2.x-dev",
+        "silverstripe-themes/simple": "^3.2"
     },
     "require-dev": {
         "phpunit/PHPUnit": "^5.7"


### PR DESCRIPTION
This adds the [simple theme](https://github.com/silverstripe-themes/silverstripe-simple) to the recipe - I'd expect that someone looking to start off a SilverStripe project would like a basic theme to run with.

Open to the conversation about whether the simple theme (or any theme at all) is appropriate 😄 