### PR TITLE
Update branch alias on master to 5.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/recipe-plugin": "^1.2",
-        "silverstripe/recipe-core": "2.x-dev",
+        "silverstripe/recipe-core": "5.x-dev",
         "silverstripe/admin": "2.x-dev",
         "silverstripe/asset-admin": "2.x-dev",
         "silverstripe/campaign-admin": "2.x-dev",
@@ -25,7 +25,7 @@
             "app/src/*"
         ],
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "5.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
Related to our decision to retag recipe to 4, the next version of recipe will be 5, not 2.

# Related issue
* https://github.com/silverstripeltd/open-sourcerers/issues/31

# Blocked by
* https://github.com/silverstripe/recipe-core/pull/26