### PR TITLE
MINOR Set default resources-dir in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://silverstripe.org",
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/recipe-plugin": "^1.2",
+        "silverstripe/recipe-plugin": "^1.4",
         "silverstripe/recipe-core": "4.4.x-dev",
         "silverstripe/admin": "1.4.x-dev",
         "silverstripe/asset-admin": "1.4.x-dev",
@@ -27,7 +27,8 @@
         ],
         "branch-alias": {
             "4.x-dev": "4.4.x-dev"
-        }
+        },
+        "resources-dir": "_resources"
     },
     "config": {
         "process-timeout": 600


### PR DESCRIPTION
People who use receipe-cms to start their new project should get the new default configurable "resources-dir".

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/7932

# Depends on 
* https://github.com/silverstripe/silverstripe-framework/pull/8519