### PR TITLE
MINOR Undo accidental dependency increment in #22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://silverstripe.org",
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/recipe-plugin": "^1.4",
+        "silverstripe/recipe-plugin": "^1.2",
         "silverstripe/recipe-core": "4.4.x-dev",
         "silverstripe/admin": "1.4.x-dev",
         "silverstripe/asset-admin": "1.4.x-dev",


### PR DESCRIPTION
#22 accidentally incremented `recipe-plugin` to 1.4 which does not exist as of yet.

Only vendor-plugin needs to be incremented.