### PR TITLE
Update Travis config to Xenial (4.4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+dist: xenial
+
+services:
+  - mysql
+  - postgresql
+
 env:
   global:
     - COMPOSER_ROOT_VERSION=4.4.x-dev


### PR DESCRIPTION
Builds are failing on the 4.4 branch, as we only updated this module's Travis config to support Xenial on the `4` branch.