### PR TITLE
Upgrade silverstripe/recipe-plugin to support composer 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.1 || ^8",
-        "silverstripe/recipe-plugin": "^1.2",
+        "silverstripe/recipe-plugin": "^1.5",
         "silverstripe/recipe-core": "4.x-dev",
         "silverstripe/admin": "1.x-dev",
         "silverstripe/asset-admin": "1.x-dev",


### PR DESCRIPTION
`The "silverstripe/recipe-plugin" plugin was skipped because it requires a Plugin API version ("^1.1") that does not match your Composer installation ("2.0.0"). You may need to run composer update with the "--no-plugins" option.`