### PR TITLE
DEP Require 3.x-dev instead of 3.5.x-dev for graphql

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "silverstripe/reports": "4.8.x-dev",
         "silverstripe/siteconfig": "4.8.x-dev",
         "silverstripe/versioned": "1.8.x-dev",
-        "silverstripe/graphql": "3.5.x-dev || 4.x-dev"
+        "silverstripe/graphql": "3.x-dev || 4.x-dev"
     },
     "require-dev": {
         "sminnee/phpunit": "^5.7",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-versioned/issues/332

`3.5.x-dev || 4.x-dev` is an odd-requirement that does not match others modules which have `3.x-dev || 4.x-dev` e.g. https://github.com/silverstripe/silverstripe-versioned/blob/1/composer.json#L28

This causes a mismatch which has lead to recipe-cms being uninstallable with grahpql on php 7.1. Instead it trys to install it with graphql 4, which is not compatibile with php7.1
https://travis-ci.com/github/silverstripe/silverstripe-versioned/jobs/505773173

