### PR TITLE
DOCS Change "SilverStripe" to "Silverstripe" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## SilverStripe CMS Recipe
+## Silverstripe CMS Recipe
 
 [![Build Status](https://api.travis-ci.com/silverstripe/recipe-cms.svg?branch=4)](https://travis-ci.com/silverstripe/recipe-cms)
 
-Base page and asset content-editing recipe for a SilverStripe ([http://silverstripe.org](http://silverstripe.org))
+Base page and asset content-editing recipe for a Silverstripe ([http://silverstripe.org](http://silverstripe.org))
 installation. This includes the modules:
 
 Provided by [silverstripe/recipe-core]:
@@ -26,7 +26,7 @@ Provided by [silverstripe/recipe-cms]:
  * [versioned](http://github.com/silverstripe/silverstripe-versioned)
 
 This can be either added to an existing project or used as a project base for creating a
-fully featured SilverStripe CMS project.
+fully featured Silverstripe CMS project.
 
 See the [recipe plugin](https://github.com/silverstripe/recipe-plugin) page for instructions on how
-SilverStripe recipes work.
+Silverstripe recipes work.


### PR DESCRIPTION
There was a relatively recent branding change from "SilverStripe" to "Silverstripe". This PR makes that change in the readme.

Note that the repository's description also still uses the old "SilverStripe" capitalisation.
![image](https://user-images.githubusercontent.com/36352093/150059652-c480e2ec-efbd-4503-acd5-e396c7516bd9.png)

See also silverstripe/silverstripe-framework#10206