### PR TITLE
DEP Require ^1.7 of silverstripe/recipe-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/recipe-plugin": "^1.5",
+        "silverstripe/recipe-plugin": "^1.7",
         "silverstripe/recipe-core": "4.x-dev",
         "silverstripe/admin": "1.x-dev",
         "silverstripe/asset-admin": "1.x-dev",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/5

This is to fix a --prefer-lowest job for silverstripe/registry - https://github.com/silverstripe/silverstripe-registry/actions/runs/4358743788/jobs/7619809879

I did a [draft PR](https://github.com/silverstripe/silverstripe-registry/pull/79) to demonstrate this working on silverstripe/registry, though the correct place to change this constraint in on silverstripe/recipe-cms