### PR TITLE
FIX Remove redudant file that recipe-core adds

### DIFF
--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,1 +1,0 @@
-/resources/


### PR DESCRIPTION
This `.gitignore` file is also [added through `silverstripe/recipe-core`](https://github.com/silverstripe/recipe-core/blob/6/public/.gitignore) which is a dependency of this recipe. There's no need to define the same file in two recipes.

This file also had an outdated folder name in it anyway - `resources/` is the old name. It was changed to `_resources/` by default in CMS 5.0 if not earlier.

## Issue

- https://github.com/silverstripe/silverstripe-assets/issues/704
